### PR TITLE
Add ['TAM', 'AAM', 'EU', 'EUK', 'MAA'] vat key support.

### DIFF
--- a/es5/lib/Item.js
+++ b/es5/lib/Item.js
@@ -54,6 +54,23 @@ var Item = function () {
         } else {
           throw new Error('Net or Gross Value is required for Item price calculation');
         }
+      } else if (typeof this._options.vat === 'string') {
+        if (['TAM', 'AAM', 'EU', 'EUK', 'MAA'].includes(this._options.vat)) {
+          if (this._options.netUnitPrice) {
+            this._options.netValue = round(this._options.netUnitPrice * this._options.quantity, currency.roundPriceExp)
+            this._options.vatValue = 0
+            this._options.grossValue = this._options.netValue + this._options.vatValue
+          }
+          else if (this._options.grossUnitPrice) {
+            this._options.grossValue = round(this._options.grossUnitPrice * this._options.quantity, currency.roundPriceExp)
+            this._options.vatValue = 0
+            this._options.netValue = this._options.grossValue - this._options.vatValue
+            this._options.netUnitPrice = round(this._options.netValue / this._options.quantity, 2)
+          }
+          else {
+            throw new Error('Net or Gross Value is required for Item price calculation')
+          }
+        }
       }
 
       indentLevel = indentLevel || 0;

--- a/src/lib/Item.js
+++ b/src/lib/Item.js
@@ -50,6 +50,23 @@ class Item {
       } else {
         throw new Error('Net or Gross Value is required for Item price calculation')
       }
+    } else if (typeof this._options.vat === 'string') {
+      if (['TAM', 'AAM', 'EU', 'EUK', 'MAA'].includes(this._options.vat)) {
+        if (this._options.netUnitPrice) {
+          this._options.netValue = round(this._options.netUnitPrice * this._options.quantity, currency.roundPriceExp)
+          this._options.vatValue = 0
+          this._options.grossValue = this._options.netValue + this._options.vatValue
+        }
+        else if (this._options.grossUnitPrice) {
+          this._options.grossValue = round(this._options.grossUnitPrice * this._options.quantity, currency.roundPriceExp)
+          this._options.vatValue = 0
+          this._options.netValue = this._options.grossValue - this._options.vatValue
+          this._options.netUnitPrice = round(this._options.netValue / this._options.quantity, 2)
+        }
+        else {
+          throw new Error('Net or Gross Value is required for Item price calculation')
+        }
+      }
     }
 
     indentLevel = indentLevel || 0


### PR DESCRIPTION
This functionality, handles the following vat keys, without throwing an error from szamlazz.hu side.
VAT calculation is fixed, only need to change vat from number to one of the followings: ['TAM', 'AAM', 'EU', 'EUK', 'MAA']