### PR TITLE
Allow for empty string Item.unit values.

### DIFF
--- a/src/lib/Item.js
+++ b/src/lib/Item.js
@@ -31,9 +31,6 @@ class Item {
     assert(typeof this._options.quantity === 'number' && this._options.quantity !== 0,
       'Valid Count value missing from item options')
 
-    assert(typeof this._options.unit === 'string' && this._options.unit.trim() !== '',
-      'Valid Unit value missing from item options')
-
     assert(typeof this._options.vat !== 'undefined' && this._options.vat !== '',
       'Valid Vat Percentage value missing from item options')
 

--- a/src/lib/XMLUtils.js
+++ b/src/lib/XMLUtils.js
@@ -37,7 +37,7 @@ function wrapWithElement (name, data, indentLevel) {
 
   let o = ''
 
-  if (typeof data !== 'undefined' && String(data).trim() !== '' && data !== null) {
+  if (typeof data !== 'undefined' && data !== null) {
     o = pad(indentLevel) + '<' + name + '>'
 
     if (Array.isArray(data)) {


### PR DESCRIPTION
Item units often seem quite redundant on invoices, so it makes sense not to include them.