### PR TITLE
feat: add logoExtra element

### DIFF
--- a/src/lib/Invoice.js
+++ b/src/lib/Invoice.js
@@ -81,8 +81,8 @@ class Invoice {
       // ['elolegszamla', ],
       // ['vegszamla', ],
       [ 'dijbekero', this._options.proforma ],
-      [ 'szamlaszamElotag', this._options.invoiceIdPrefix ],
       [ 'logoExtra', this._options.logoImage ],
+      [ 'szamlaszamElotag', this._options.invoiceIdPrefix ],
       [ 'fizetve', this._options.paid ]
     ], indentLevel)
 

--- a/src/lib/Invoice.js
+++ b/src/lib/Invoice.js
@@ -34,6 +34,7 @@ class Invoice {
     this._options.invoiceIdPrefix = options.invoiceIdPrefix
     this._options.paid = options.paid
     this._options.comment = options.comment
+    this._options.logoImage = options.logoImage
   }
 
   _generateXML (indentLevel) {
@@ -81,6 +82,7 @@ class Invoice {
       // ['vegszamla', ],
       [ 'dijbekero', this._options.proforma ],
       [ 'szamlaszamElotag', this._options.invoiceIdPrefix ],
+      [ 'logoExtra', this._options.logoImage ],
       [ 'fizetve', this._options.paid ]
     ], indentLevel)
 


### PR DESCRIPTION
szamlazz.hu api can pick from several logos for the invoices

quoting their helpdesk on how to set this up

> Amennyiben elküldi számunkra a használni kívánt logókat, azt feltöltjük rendszerünkben, majd a számlakészítési kérés XML-ben erre hivatkozva az extra logó sorban megadható, hogy az adott számlán mely logó megjelenését szeretnék elérni.
> A több logó használata kizárólag API számlázás esetén használható, kézi számlázás esetén csak a fiókban feltöltött egyetlen logó használható.
> Javasoljuk, hogy az összes, használni kívánt logót küldjék el nekünk.

> A logó mérete lehetőleg ne legyen nagyobb, mint 50 kilobájt és amennyiben négyzet alakú a kép, az a legideálisabb. Típusként a következő formátumokat tudjuk fogadni: jpeg, jpg, png vagy gif.

> A küldött fájlokat optimalizáljuk annak érdekében, hogy a számlán a legjobban mutasson, ezért konkrét szélességi és magassági méreteket nem adnánk meg. Érdemes minél kevesebb szabad (fehér) helyet hagyni a konkrét logó körül és jó felbontásban továbbítani az felénk.

After they've set up the logos in their system, users can refer to them by their filenames in the "logoExtra" field in the API XML

Since "logoExtra" is not really descriptive, I've implemented the new option on the Invoice with the name `logoImage`