### PR TITLE
feat: add tax subject (adoalany)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "szamlazz.js",
-  "version": "1.0.9",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/lib/Buyer.js
+++ b/src/lib/Buyer.js
@@ -3,15 +3,21 @@
 const assert = require('assert')
 const merge = require('merge')
 const XMLUtils = require('./XMLUtils')
+const Constants = require('./Constants').setup()
 
 const defaultOptions = {
-  postAddress: {}
+  postAddress: {},
+  taxSubject: Constants.TaxSubject.Unknown
 }
 
 class Buyer {
   constructor (options) {
     this._options = merge.recursive(true, defaultOptions, options || {})
+    this._options.taxSubject = options.taxSubject || defaultOptions.taxSubject
 
+    assert(this._options.taxSubject instanceof Constants.Interface.TaxSubject,
+      'Valid TaxSubject field missing from buyer invoice options')
+  
     assert(typeof this._options.name === 'string' && this._options.name.trim().length > 0,
       'Valid Name field missing from buyer options')
 
@@ -36,6 +42,7 @@ class Buyer {
       [ 'cim', this._options.address ],
       [ 'email', this._options.email ],
       [ 'sendEmail', this._options.sendEmail ],
+      [ 'adoalany', this._options.taxSubject ],
       [ 'adoszam', this._options.taxNumber ],
       [ 'adoszamEU', this._options.taxNumberEU ],
       [ 'postazasiNev', this._options.postAddress.name ],

--- a/src/lib/Constants.js
+++ b/src/lib/Constants.js
@@ -34,6 +34,17 @@ class PaymentMethod {
   }
 }
 
+class TaxSubject {
+  constructor (value, comment) {
+    this.value = value
+    this.comment = comment
+  }
+
+  toString () {
+    return this.value
+  }
+}
+
 exports.setup = function (_module) {
   _module = _module || {}
 
@@ -83,7 +94,15 @@ exports.setup = function (_module) {
     PayPal: new PaymentMethod('PayPal', 'PayPal')
   }
 
-  _module.Interface = { Currency, Language, PaymentMethod }
+  _module.TaxSubject = {
+    NonEUCompany: new TaxSubject(7, 'Company outside EU'),
+    EUCompany: new TaxSubject(6, 'Company within EU'),
+    HungarianTaxID: new TaxSubject(1, 'Has Hungarian VAT ID'),
+    Unknown: new TaxSubject(0, 'Unknown VAT status'),
+    NoTaxID: new TaxSubject(-1, 'Has no Hungarian VAT ID')
+  }
+
+  _module.Interface = { Currency, Language, PaymentMethod, TaxSubject }
 
   return _module
 }

--- a/tests/resources/setup.js
+++ b/tests/resources/setup.js
@@ -63,6 +63,7 @@ exports.createBuyer = function (Szamlazz) {
       city: 'City',
       address: 'Some street address'
     },
+    taxSubject: Szamlazz.TaxSubject.Unknown,
     issuerName: '',
     identifier: 1,
     phone: '',

--- a/tests/resources/xmlszamla.xsd
+++ b/tests/resources/xmlszamla.xsd
@@ -10,6 +10,7 @@
             <element name="cim" type="string" maxOccurs="1" minOccurs="1"></element>
             <element name="email" type="string" maxOccurs="1" minOccurs="0"></element>
             <element name="sendEmail" type="boolean" maxOccurs="1" minOccurs="0"></element>
+            <element name="adoalany" type="int" maxOccurs="1" minOccurs="0"></element>
             <element name="adoszam" type="string" maxOccurs="1" minOccurs="0"></element>
             <element name="adoszamEU" type="string" maxOccurs="1" minOccurs="0"></element>
             <element name="postazasiNev" type="string" maxOccurs="1" minOccurs="0"></element>


### PR DESCRIPTION
To comply with Hungarian tax laws szamlazz.hu users has to provide tax subject statuses of buyers.

https://www.szamlazz.hu/szamla/tudastar/funkcionalitas/vevo_adoszama_a_szamlan

field in XSD

https://docs.szamlazz.hu/#xsd-scheme-compliance