### PR TITLE
kulcstartojelszo should be removed from the invoice xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 .idea
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [4.2.1] - 2021-08-18
+### Removed
+- Remove the `passphrase` client option because it is no longer allowed in the szamlazz.hu API
+
 ## [4.2.0] - 2021-06-22
 
 - Add tax subject (adóalany).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ const szamlazzClient = new szamlazz.Client({
   user: 'USERNAME',
   password: 'PASSWORD',
   eInvoice: false, // create e-invoice. optional, default: false
-  passphrase: '', // passphrase for e-invoice. optional
   requestInvoiceDownload: true, // downloads the issued pdf invoice. optional, default: false
   downloadedInvoiceCount: 1, // optional, default: 1
   responseVersion: 1 // optional, default: 1
@@ -34,7 +33,6 @@ Or use "Számla Agent" key to authenticate the client
 const szamlazzClient = new szamlazz.Client({
   authToken: 'SZAMLAAGENTKEY',
   eInvoice: false, // create e-invoice. optional, default: false
-  passphrase: '', // passphrase for e-invoice. optional
   requestInvoiceDownload: true, // downloads the issued pdf invoice. optional, default: false
   downloadedInvoiceCount: 1, // optional, default: 1
   responseVersion: 1 // optional, default: 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "szamlazz.js",
-  "version": "4.1.0",
+  "version": "4.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "szamlazz.js",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Integration module for the szamlazz.hu online invoice provider",
   "main": "index.js",
   "jsnext:main": "./src/index.js",

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -151,7 +151,6 @@ class Client {
       XMLUtils.wrapWithElement('beallitasok', [
         ...this._getAuthFields(),
         [ 'eszamla', this._options.eInvoice ],
-        [ 'kulcstartojelszo', this._options.passphrase ],
         [ 'szamlaLetoltes', this._options.requestInvoiceDownload ],
         [ 'szamlaLetoltesPld', this._options.downloadedInvoiceCount ],
         [ 'valaszVerzio', this._options.responseVersion ]

--- a/tests/resources/setup.js
+++ b/tests/resources/setup.js
@@ -7,7 +7,6 @@ exports.createClient = function (Szamlazz) {
     user: 'USERNAME',
     password: 'PASSWORD',
     eInvoice: false,
-    passphrase: '',
     requestInvoiceDownload: true,
     downloadedInvoiceCount: 0,
     responseVersion: 1
@@ -18,7 +17,6 @@ exports.createTokenClient = function (Szamlazz) {
   return new Szamlazz.Client({
     authToken: 'AUTHTOKEN',
     eInvoice: false,
-    passphrase: '',
     requestInvoiceDownload: true,
     downloadedInvoiceCount: 0,
     responseVersion: 1

--- a/tests/resources/xmlszamla.xsd
+++ b/tests/resources/xmlszamla.xsd
@@ -51,7 +51,6 @@
             <element name="jelszo" type="string" maxOccurs="1" minOccurs="0"></element>
             <element name="szamlaagentkulcs" type="string" maxOccurs="1" minOccurs="0"></element>
             <element name="eszamla" type="boolean" maxOccurs="1" minOccurs="1"></element>
-            <element name="kulcstartojelszo" type="string" maxOccurs="1" minOccurs="0"></element>
             <element name="szamlaLetoltes" type="boolean" maxOccurs="1" minOccurs="1"></element>
             <element name="szamlaLetoltesPld" type="int" maxOccurs="1" minOccurs="0"></element>
             <element name="valaszVerzio" type="int" maxOccurs="1" minOccurs="0"></element>


### PR DESCRIPTION
I am not sure why do we have the `passphrase` client option in the first place. 😊  I have never used it. But the result of this option is the 'kulcstartojelszo' field in the invoice xml's `beallitasok` type.


## The problem

**And the szamlazz.hu API has started to throw errors because this field is no longer allowed in the invoice XSD.**

The error:
> XML beolvasási hiba. cvc-complex-type.2.4.a: Invalid content was found starting with element 'kulcstartojelszo'. One of '{"http://www.szamlazz.hu/xmlszamla":szamlaLetoltes}' is expected.


The Invoice XSD no longer contains the `kulcstartojelszo` field according to their documentation.

```
<complexType name="beallitasokTipus">
        <sequence>
            <element name="felhasznalo" type="string" maxOccurs="1" minOccurs="0"></element>
            <element name="jelszo" type="string" maxOccurs="1" minOccurs="0"></element>
            <element name="szamlaagentkulcs" type="string" maxOccurs="1" minOccurs="0"></element>
            <element name="eszamla" type="boolean" maxOccurs="1" minOccurs="1"></element>
            <element name="szamlaLetoltes" type="boolean" maxOccurs="1" minOccurs="1"></element>
            <element name="szamlaLetoltesPld" type="int" maxOccurs="1" minOccurs="0"></element>
            <element name="valaszVerzio" type="int" maxOccurs="1" minOccurs="0"></element>
            <element name="aggregator" type="string" maxOccurs="1" minOccurs="0"></element>
            <element name="guardian" type="boolean" maxOccurs="1" minOccurs="0"></element>
            <element name="cikkazoninvoice" type="boolean" maxOccurs="1" minOccurs="0"></element>

        </sequence>
    </complexType>
```

I have found in the changelog about this change. It is their PHP API, but still, it should be relevant.

👀 https://docs.szamlazz.hu/changelog.md

```
## [2.10.6] - 2021.07.30

### Removed

- removed own certificate, keychain settings functions (setKeychain, setCertificationFileName)
    - src/szamlaagent/SzamlaAgent.php
    - src/szamlaagent/SzamlaAgentSettings.php
- removed "kulcstartojelszo" field from generated xml
```

## The solution

Removing this field resolves the problem.

I have tried to update our changelog and package.json, but not sure about the version number 🤔 🙂 