### PR TITLE
Handle PDF as binary content in `reverseInvoice` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Response
   invoiceId: 'WXSKA-2020-00', // The id of the created reverse invoice
   netTotal: '1000',           // Total value of the reverse invoice excl. VAT
   grossTotal: '1270'          // Total value of the reverse invoice incl. VAT
-  pdf: null                   // the PDF content as string if requestInvoiceDownload was true, otherwise false
+  pdf: null                   // the PDF content as a Buffer if requestInvoiceDownload was true, otherwise null
 }
 ```
 

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -30,10 +30,10 @@ class Client {
 
     if (!this.useToken) {
       assert(typeof this._options.user === 'string' && this._options.user.trim().length > 1,
-      'Valid User field missing form client options')
+        'Valid User field missing form client options')
 
       assert(typeof this._options.password === 'string' && this._options.password.trim().length > 1,
-      'Valid Password field missing form client options')
+        'Valid Password field missing form client options')
     }
 
     this._cookieJar = request.jar()
@@ -91,20 +91,17 @@ class Client {
     this._sendRequest(
       'action-szamla_agent_st',
       xml,
-      'utf8',
+      null,
       (httpResponse, cb) => {
-        let pdf = null
         const contentType = httpResponse.headers['content-type']
-
-        if (contentType && contentType.indexOf('application/pdf') === 0) {
-          pdf = httpResponse.body
-        }
+        const isPdfAvailable = options.requestInvoiceDownload
+          && contentType && contentType.indexOf('application/pdf') === 0
 
         cb(null, {
           invoiceId: httpResponse.headers.szlahu_szamlaszam,
           netTotal: httpResponse.headers.szlahu_nettovegosszeg,
           grossTotal: httpResponse.headers.szlahu_bruttovegosszeg,
-          pdf: pdf
+          pdf: isPdfAvailable ? httpResponse.body : null
         })
       },
       cb)
@@ -120,7 +117,7 @@ class Client {
           invoiceId: httpResponse.headers.szlahu_szamlaszam,
           netTotal: httpResponse.headers.szlahu_nettovegosszeg,
           grossTotal: httpResponse.headers.szlahu_bruttovegosszeg
-        });
+        })
       },
       cb)
   }
@@ -163,7 +160,7 @@ class Client {
   _sendRequest (fileFieldName, data, encoding, getResult, cb) {
     const formData = {}
 
-    formData[ fileFieldName ] = {
+    formData[fileFieldName] = {
       value: data,
       options: {
         filename: 'request.xml',
@@ -207,7 +204,7 @@ class Client {
               cb(null, result, httpResponse)
             })
           } else {
-            result.pdf = body
+            result.pdf = result.pdf ? result.pdf : body
             cb(null, result, httpResponse)
           }
         } else {

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -194,22 +194,17 @@ class Client {
           return cb(err, body, httpResponse)
         }
 
-        if (this._options.requestInvoiceDownload) {
-          if (this._options.responseVersion === 2) {
-            XMLUtils.xml2obj(body, { 'xmlszamlavalasz.pdf': 'pdf' }, (err3, parsed) => {
-              if (err3) {
-                return cb(err3, body, httpResponse)
-              }
-              result.pdf = new Buffer(parsed.pdf, 'base64')
-              cb(null, result, httpResponse)
-            })
-          } else {
-            result.pdf = result.pdf ? result.pdf : body
-            cb(null, result, httpResponse)
-          }
-        } else {
-          cb(null, result, httpResponse)
+
+        if (this._options.requestInvoiceDownload && this._options.responseVersion === 2) {
+          XMLUtils.xml2obj(body, { 'xmlszamlavalasz.pdf': 'pdf' }, (err3, parsed) => {
+            if (err3) {
+              return cb(err3, body, httpResponse)
+            }
+            result.pdf = new Buffer(parsed.pdf, 'base64')
+          })
         }
+
+        cb(null, result, httpResponse)
       })
     })
   }

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -202,6 +202,8 @@ class Client {
             }
             result.pdf = new Buffer(parsed.pdf, 'base64')
           })
+        } else if (this._options.requestInvoiceDownload && this._options.responseVersion === 1) {
+          result.pdf = httpResponse.body;
         }
 
         cb(null, result, httpResponse)


### PR DESCRIPTION
PDF content generated with `reverseInvoice` method was handled as a UTF8 string, so it can not be converted to the original binary format, and it cannot be saved directly to the filesystem as a valid PDF file.

I changed code to handle the response as binary content, so `reverseInvoice` returns PDF as a Buffer from now. This format is also consistent with the output of `issueInvoice`.

Incrementing major version number and extending changelog is necessary before merging this PR. Please let me know if you are ready to approve these changes, and I can do these steps too.

It closes #23 