### PR TITLE
chore: set which files deploy to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
   },
   "author": "Elastic Wings Ltd.",
   "license": "MIT",
+  "files": [
+    "index.js",
+    "lib/"
+  ],
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
I think good practice to publish only the files that needed.
The unpacked size changes from `66.8 kB` to `29.6 kB`.

the result of the `npm pack` command
<details>
<summary>Before</summary>

npm notice 
npm notice 📦  szamlazz.js@6.0.0
npm notice === Tarball Contents === 
npm notice 526B   .github/workflows/ci.yml                  
npm notice 2.8kB  CHANGELOG.md                              
npm notice 1.1kB  LICENSE                                   
npm notice 5.6kB  README.md                                 
npm notice 470B   index.js                                  
npm notice 2.2kB  lib/Buyer.js                              
npm notice 6.2kB  lib/Client.js                             
npm notice 2.9kB  lib/Constants.js                          
npm notice 4.1kB  lib/Invoice.js                            
npm notice 3.4kB  lib/Item.js                               
npm notice 698B   lib/Seller.js                             
npm notice 2.0kB  lib/XMLUtils.js                           
npm notice 861B   package.json                              
npm notice 2.5kB  tests/buyer.spec.js                       
npm notice 7.1kB  tests/client.spec.js                      
npm notice 2.4kB  tests/invoice.spec.js                     
npm notice 3.7kB  tests/item.spec.js                        
npm notice 2.6kB  tests/resources/setup.js                  
npm notice 242B   tests/resources/success_with_pdf.xml      
npm notice 218B   tests/resources/success_without_pdf.xml   
npm notice 259B   tests/resources/unknown_invoice_number.xml
npm notice 13.9kB tests/resources/xmlszamla.xsd             
npm notice 848B   tests/seller.spec.js                      
npm notice === Tarball Details === 
npm notice name:          szamlazz.js                             
npm notice version:       6.0.0                                   
npm notice filename:      szamlazz.js-6.0.0.tgz                   
npm notice package size:  14.9 kB                                 
npm notice unpacked size: 66.8 kB                                 
npm notice shasum:        1bfc4c062ec24463fa605b31e613ac4ed4f2ac55
npm notice integrity:     sha512-h4ycd7Yy0NZA3[...]Vh9qj+ZFhPa9g==
npm notice total files:   23                                      
npm notice 
szamlazz.js-6.0.0.tgz

</details>

<details>
<summary>After</summary>

npm notice 
npm notice 📦  szamlazz.js@6.0.0
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE         
npm notice 5.6kB README.md       
npm notice 470B  index.js        
npm notice 2.2kB lib/Buyer.js    
npm notice 6.2kB lib/Client.js   
npm notice 2.9kB lib/Constants.js
npm notice 4.1kB lib/Invoice.js  
npm notice 3.4kB lib/Item.js     
npm notice 698B  lib/Seller.js   
npm notice 2.0kB lib/XMLUtils.js 
npm notice 906B  package.json    
npm notice === Tarball Details === 
npm notice name:          szamlazz.js                             
npm notice version:       6.0.0                                   
npm notice filename:      szamlazz.js-6.0.0.tgz                   
npm notice package size:  8.3 kB                                  
npm notice unpacked size: 29.6 kB                                 
npm notice shasum:        b6ea7c5757396ce41f39ca6b4a67447e17475c14
npm notice integrity:     sha512-pyAeiTUg8bhPa[...]SrEAXjdXnqCQA==
npm notice total files:   11                                      
npm notice 
szamlazz.js-6.0.0.tgz

</details>