### PR TITLE
test: remove unnecessary done() and use "rejectedWith" instead of try/catch

### DIFF
--- a/tests/buyer.spec.js
+++ b/tests/buyer.spec.js
@@ -8,18 +8,16 @@ const expect = chai.expect
 import {Buyer} from '../index.js'
 import {createBuyer} from './resources/setup.js'
 
-let buyer
-
-beforeEach(function (done) {
-  buyer = createBuyer(Buyer)
-  done()
-})
-
 describe('Buyer', function () {
+  let buyer
+
+  beforeEach(function () {
+    buyer = createBuyer(Buyer)
+  })
+
   describe('constructor', function () {
-    it('should set _options property', function (done) {
+    it('should set _options property', function () {
       expect(buyer).to.have.property('_options').that.is.an('object')
-      done()
     })
   })
 
@@ -39,59 +37,50 @@ describe('Buyer', function () {
       beforeEach(function (done) {
         parser.parseString(buyer._generateXML(), function (err, result) {
           if (!err) obj = result.vevo
+
+          done()
         })
 
-        done()
       })
 
-      it('should have `nev` property', function (done) {
+      it('should have `nev` property', function () {
         expect(obj).to.have.property('nev')
-        done()
       })
 
-      it('should have `irsz` property', function (done) {
+      it('should have `irsz` property', function () {
         expect(obj).to.have.property('irsz')
-        done()
       })
 
-      it('should have `telepules` property', function (done) {
+      it('should have `telepules` property', function () {
         expect(obj).to.have.property('telepules')
-        done()
       })
 
-      it('should have `cim` property', function (done) {
+      it('should have `cim` property', function () {
         expect(obj).to.have.property('cim')
-        done()
       })
 
-      it('should have `adoszam` property', function (done) {
+      it('should have `adoszam` property', function () {
         expect(obj).to.have.property('adoszam')
-        done()
       })
 
-      it('should have `postazasiNev` property', function (done) {
+      it('should have `postazasiNev` property', function () {
         expect(obj).to.have.property('postazasiNev')
-        done()
       })
 
-      it('should have `postazasiIrsz` property', function (done) {
+      it('should have `postazasiIrsz` property', function () {
         expect(obj).to.have.property('postazasiIrsz')
-        done()
       })
 
-      it('should have `postazasiTelepules` property', function (done) {
+      it('should have `postazasiTelepules` property', function () {
         expect(obj).to.have.property('postazasiTelepules')
-        done()
       })
 
-      it('should have `postazasiCim` property', function (done) {
+      it('should have `postazasiCim` property', function () {
         expect(obj).to.have.property('postazasiCim')
-        done()
       })
 
-      it('should have `azonosito` property', function (done) {
+      it('should have `azonosito` property', function () {
         expect(obj).to.have.property('azonosito')
-        done()
       })
     })
   })

--- a/tests/client.spec.js
+++ b/tests/client.spec.js
@@ -50,19 +50,16 @@ describe('Client', () => {
   })
 
   describe('constructor', () => {
-    it('should set _options property', done => {
+    it('should set _options property', () => {
       expect(client).to.have.property('_options').that.is.an('object')
-      done()
     })
 
-    it('should set user', done => {
+    it('should set user', () => {
       expect(client._options).to.have.property('user').that.is.a('string')
-      done()
     })
 
-    it('should set password', done => {
+    it('should set password', () => {
       expect(client._options).to.have.property('password').that.is.a('string')
-      done()
     })
   })
 
@@ -71,11 +68,7 @@ describe('Client', () => {
       it('should handle failed requests', async () => {
         axiosStub.resolves(new Promise(r => r({ status: 404, statusText: 'Not found' })))
 
-        try {
-          await client.issueInvoice(invoice)
-        } catch (e) {
-          expect(e.message).to.be.string('404 Not found')
-        }
+        await expect(client.issueInvoice(invoice)).rejectedWith('404 Not found')
       })
     })
 
@@ -89,11 +82,7 @@ describe('Client', () => {
           }
         })))
 
-        try {
-          await client.issueInvoice(invoice)
-        } catch (e) {
-          expect(e.message).to.be.string('Some error message from the remote service')
-        }
+        await expect(client.issueInvoice(invoice)).rejectedWith('Some error message from the remote service')
       })
     })
 
@@ -211,13 +200,9 @@ describe('Client', () => {
       })
 
       it('should throw error', async () => {
-        try {
-          const res = await client.getInvoiceData({
-            invoiceId: 'TEST-ISSUE-NUMBER'
-          })
-        } catch (e) {
-          expect(e.message).to.be.string('Hiányzó adat: számla agent xml lekérés hiba (ismeretlen számlaszám).')
-        }
+        await expect(client.getInvoiceData({
+          invoiceId: 'TEST-ISSUE-NUMBER'
+        })).rejectedWith('Hiányzó adat: számla agent xml lekérés hiba (ismeretlen számlaszám).')
       })
     })
   })
@@ -231,23 +216,19 @@ describe('Client with auth token', () => {
       tokenClient = createTokenClient(Client)
     })
 
-    it('should set _options property', done => {
+    it('should set _options property', () => {
       expect(tokenClient).to.have.property('_options').that.is.an('object')
-      done()
     })
 
-    it('should set authToken', done => {
+    it('should set authToken', () => {
       expect(tokenClient._options).to.have.property('authToken').that.is.a('string')
-      done()
     })
 
-    it('should not set user', done => {
+    it('should not set user', () => {
       expect(tokenClient._options).to.not.have.property('user')
-      done()
     })
-    it('should not set password', done => {
+    it('should not set password', () => {
       expect(tokenClient._options).to.not.have.property('password')
-      done()
     })
   })
 

--- a/tests/invoice.spec.js
+++ b/tests/invoice.spec.js
@@ -8,51 +8,42 @@ const expect = chai.expect
 import {Buyer, Invoice, Item, Seller} from '../index.js'
 import {createSeller, createBuyer, createSoldItemNet, createSoldItemGross, createInvoice} from './resources/setup.js'
 
-let seller
-let buyer
-let soldItem1
-let soldItem2
-let invoice
-
-beforeEach(function (done) {
-  seller = createSeller(Seller)
-  buyer = createBuyer(Buyer)
-  soldItem1 = createSoldItemNet(Item)
-  soldItem2 = createSoldItemGross(Item)
-  invoice = createInvoice(Invoice, seller, buyer, [ soldItem1, soldItem2 ])
-
-  done()
-})
-
 describe('Invoice', function () {
+  let seller
+  let buyer
+  let soldItem1
+  let soldItem2
+  let invoice
+
+  beforeEach(function () {
+    seller = createSeller(Seller)
+    buyer = createBuyer(Buyer)
+    soldItem1 = createSoldItemNet(Item)
+    soldItem2 = createSoldItemGross(Item)
+    invoice = createInvoice(Invoice, seller, buyer, [ soldItem1, soldItem2 ])
+  })
+
   describe('constructor', function () {
-    it('should set _options property', function (done) {
+    it('should set _options property', function () {
       expect(invoice).to.have.property('_options').that.is.an('object')
-      done()
     })
 
-    it('should set seller', function (done) {
+    it('should set seller', function () {
       expect(invoice._options).to.have.property('seller').to.be.an.instanceof(Seller)
-      done()
     })
 
-    it('should set buyer', function (done) {
+    it('should set buyer', function () {
       expect(invoice._options).to.have.property('buyer').to.be.an.instanceof(Buyer)
-      done()
     })
 
-    it('should set items', function (done) {
-      expect(invoice._options).to.have.property('items').that.is.an('array')
-      done()
-    })
+    it('should set items', function () {
+      expect(invoice._options).to.have.property('items').that.is.an('array')})
   })
   describe('_generateXML', function () {
     it('should return valid XML', function (done) {
       parser.parseString('<wrapper>' + invoice._generateXML() + '</wrapper>', function (err, result) {
-        if (!err) {
-          expect(result).to.have.property('wrapper').that.is.an('object')
-          done()
-        }
+        expect(result).to.have.property('wrapper').that.is.an('object')
+        done()
       })
     })
 
@@ -62,29 +53,25 @@ describe('Invoice', function () {
       beforeEach(function (done) {
         parser.parseString('<wrapper>' + invoice._generateXML() + '</wrapper>', function (err, result) {
           if (!err) obj = result.wrapper
+
+          done()
         })
-
-        done()
       })
 
-      it('should have `fejlec` node', function (done) {
+      it('should have `fejlec` node', function () {
         expect(obj).to.have.property('fejlec')
-        done()
       })
 
-      it('should have `elado` node', function (done) {
+      it('should have `elado` node', function () {
         expect(obj).to.have.property('elado')
-        done()
       })
 
-      it('should have `vevo` node', function (done) {
+      it('should have `vevo` node', function () {
         expect(obj).to.have.property('vevo')
-        done()
       })
 
-      it('should have `tetelek` node', function (done) {
+      it('should have `tetelek` node', function () {
         expect(obj).to.have.property('tetelek')
-        done()
       })
     })
   })

--- a/tests/item.spec.js
+++ b/tests/item.spec.js
@@ -8,23 +8,22 @@ const expect = chai.expect
 import {Buyer, Invoice, Item, Seller} from '../index.js'
 import {createSeller, createBuyer, createSoldItemNet, createSoldItemGross, createInvoice} from './resources/setup.js'
 
-let seller
-let buyer
-let soldItem1
-let soldItem2
-let invoice
-
-beforeEach(function (done) {
-  seller = createSeller(Seller)
-  buyer = createBuyer(Buyer)
-  soldItem1 = createSoldItemNet(Item)
-  soldItem2 = createSoldItemGross(Item)
-  invoice = createInvoice(Invoice, seller, buyer, [ soldItem1, soldItem2 ])
-
-  done()
-})
-
 describe('Item', function () {
+
+  let seller
+  let buyer
+  let soldItem1
+  let soldItem2
+  let invoice
+
+  beforeEach(function () {
+    seller = createSeller(Seller)
+    buyer = createBuyer(Buyer)
+    soldItem1 = createSoldItemNet(Item)
+    soldItem2 = createSoldItemGross(Item)
+    invoice = createInvoice(Invoice, seller, buyer, [ soldItem1, soldItem2 ])
+  })
+
   describe('constructor', function () {
     it('should set _options property', function (done) {
       expect(soldItem1).to.have.property('_options').that.is.an('object')

--- a/tests/seller.spec.js
+++ b/tests/seller.spec.js
@@ -8,29 +8,24 @@ const expect = chai.expect
 import {Seller} from '../index.js'
 import {createSeller} from './resources/setup.js'
 
-let seller
-
-beforeEach(function (done) {
-  seller = createSeller(Seller)
-
-  done()
-})
-
 describe('Seller', function () {
+  let seller
+
+  beforeEach(function () {
+    seller = createSeller(Seller)
+  })
+
   describe('constructor', function () {
-    it('should set _options property', function (done) {
+    it('should set _options property', function () {
       expect(seller).to.have.property('_options').that.is.an('object')
-      done()
     })
   })
 
   describe('_generateXML', function () {
     it('should return valid XML', function (done) {
       parser.parseString(seller._generateXML(), function (err, result) {
-        if (!err) {
-          expect(result).to.have.property('elado').that.is.an('object')
-          done()
-        }
+        expect(result).to.have.property('elado').that.is.an('object')
+        done()
       })
     })
   })


### PR DESCRIPTION
The problem of the following code snippet is if try block does not throw an exception then the catch block will not call,
so the assertion will not run and the test will pass.

```javascript
try {
  await client.issueInvoice(invoice)
} catch (e) {
  expect(e.message).to.be.string('Some error message from the remote service')
}
```