### PR TITLE
feat: Add new timeout field to Client options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ const szamlazzClient = new Client({
   requestInvoiceDownload: true, // downloads the issued pdf invoice. optional, default: false
   downloadedInvoiceCount: 1, // optional, default: 1
   responseVersion: 1 // optional, default: 1
+  timeout: 1000 // optional, default: 0, request timeout in ms (0 = no timeout)
 })
 ```
 
@@ -49,6 +50,7 @@ const szamlazzClient = new Client({
   requestInvoiceDownload: true, // downloads the issued pdf invoice. optional, default: false
   downloadedInvoiceCount: 1, // optional, default: 1
   responseVersion: 1 // optional, default: 1
+  timeout: 0 // optional, default: 0, request timeout in ms (0 = no timeout)
 })
 ```
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -13,7 +13,8 @@ const defaultOptions = {
   eInvoice: false,
   requestInvoiceDownload: false,
   downloadedInvoiceCount: 1,
-  responseVersion: 1
+  responseVersion: 1,
+  timeout: 0,
 }
 
 export class Client {
@@ -145,6 +146,7 @@ export class Client {
       },
       jar: this._cookieJar,
       withCredentials: true,
+      timeout: this._options.timeout,
     }
 
     if (isBinaryDownload) {


### PR DESCRIPTION
Allow users to specify a maximum time (in ms) for each request sent by this library. This new `timeout` field is passed directly to `axios`, the HTTP library used under the hood.