### PR TITLE
feat: add taxNumberGroup/csoportazonosito to Buyer

### DIFF
--- a/lib/Buyer.js
+++ b/lib/Buyer.js
@@ -43,6 +43,7 @@ export class Buyer {
       [ 'adoalany', this._options.taxSubject ],
       [ 'adoszam', this._options.taxNumber ],
       [ 'adoszamEU', this._options.taxNumberEU ],
+      [ 'csoportazonosito', this._options.taxNumberGroup ],    
       [ 'postazasiNev', this._options.postAddress.name ],
       [ 'postazasiOrszag', this._options.postAddress.country ],
       [ 'postazasiIrsz', this._options.postAddress.zip ],


### PR DESCRIPTION
It is probably a rare case, because there are a total of 240 such groups of companies in the our country, but we have one such registered customer. Is it possible to include this addition in the package? Thanks in advance!