### PR TITLE
fix: remove `reponseEncoding` axios request option

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -158,7 +158,6 @@ export class Client {
 
     if (isBinaryDownload) {
       axiosOptions.responseType = 'arraybuffer'
-      axiosOptions.reponseEncoding = 'binary'
     }
 
     const httpResponse = await this.#axiosInstance.post('https://www.szamlazz.hu/szamla/', formData.getBuffer(), axiosOptions)


### PR DESCRIPTION
It is not necessary to set when `responseType` is `arraybuffer`
closes #75