### PR TITLE
fix: support 0 unit price

### DIFF
--- a/lib/Item.js
+++ b/lib/Item.js
@@ -33,11 +33,11 @@ export class Item {
       'Valid Vat Percentage value missing from item options')
 
     if (typeof this._options.vat === 'number') {
-      if (this._options.netUnitPrice) {
+      if (typeof this._options.netUnitPrice === 'number') {
         this._options.netValue = round(this._options.netUnitPrice * this._options.quantity, currency.roundPriceExp)
         this._options.vatValue = round(this._options.netValue * this._options.vat / 100, currency.roundPriceExp)
         this._options.grossValue = this._options.netValue + this._options.vatValue
-      } else if (this._options.grossUnitPrice) {
+      } else if (typeof this._options.grossUnitPrice === 'number') {
         this._options.grossValue = round(this._options.grossUnitPrice * this._options.quantity, currency.roundPriceExp)
         this._options.vatValue = round(this._options.grossValue / (this._options.vat + 100) * this._options.vat, currency.roundPriceExp)
         this._options.netValue = this._options.grossValue - this._options.vatValue
@@ -47,12 +47,12 @@ export class Item {
       }
     } else if (typeof this._options.vat === 'string') {
       if (['TAM', 'AAM', 'EU', 'EUK', 'MAA', 'ÁKK', 'TEHK', 'HO', 'KBAET'].includes(this._options.vat)) {
-        if (this._options.netUnitPrice) {
+        if (typeof this._options.netUnitPrice === 'number') {
           this._options.netValue = round(this._options.netUnitPrice * this._options.quantity, currency.roundPriceExp)
           this._options.vatValue = 0
           this._options.grossValue = this._options.netValue + this._options.vatValue
         }
-        else if (this._options.grossUnitPrice) {
+        else if (typeof this._options.grossUnitPrice === 'number') {
           this._options.grossValue = round(this._options.grossUnitPrice * this._options.quantity, currency.roundPriceExp)
           this._options.vatValue = 0
           this._options.netValue = this._options.grossValue - this._options.vatValue

--- a/tests/item.spec.js
+++ b/tests/item.spec.js
@@ -5,7 +5,7 @@ const parser = new xml2js.Parser()
 import {expect} from 'chai'
 
 import {Buyer, Invoice, Item, Seller} from '../index.js'
-import {createSeller, createBuyer, createSoldItemNet, createSoldItemGross, createInvoice, createSoldItemNetZero, createSoldItemGrossZero} from './resources/setup.js'
+import {createSeller, createBuyer, createSoldItemNet, createSoldItemGross, createInvoice} from './resources/setup.js'
 
 describe('Item', function () {
 

--- a/tests/item.spec.js
+++ b/tests/item.spec.js
@@ -58,22 +58,20 @@ describe('Item', function () {
       expect(price).is.a('number')
       done()
     })
-
-    it('should set netUnitPrice or grossUnitPrice to 0', function (done) {
-      let netUnitPriceZero = soldItem1ZeroNetPrice._options.netUnitPrice;
-      let grossUnitPriceZero = soldItem1ZeroGrossPrice._options.grossUnitPrice;
-      expect(netUnitPriceZero).is.a('number').to.equal(0)
-      expect(grossUnitPriceZero).is.a('number').to.equal(0)
-      done()
-    })
   })
-
+  
   describe('_generateXML', function () {
     it('should calculate netUnitPrice', function (done) {
       expect(soldItem1._options).to.have.property('netUnitPrice').that.is.a('number')
       done()
     })
 
+    it('should set netUnitPrice or grossUnitPrice to 0', function (done) {
+      expect(soldItem1ZeroNetPrice._options).to.have.property('netUnitPrice').that.is.a('number').to.equal(0)
+      expect(soldItem1ZeroGrossPrice._options).to.have.property('grossUnitPrice').that.is.a('number').to.equal(0)
+      done()
+    })
+    
     it('should calculate vatValue', function (done) {
       expect(soldItem1._options).to.have.property('vatValue').that.is.a('number')
       done()

--- a/tests/item.spec.js
+++ b/tests/item.spec.js
@@ -12,8 +12,6 @@ describe('Item', function () {
   let seller
   let buyer
   let soldItem1
-  let soldItem1ZeroNetPrice
-  let soldItem1ZeroGrossPrice
   let soldItem2
   let invoice
 
@@ -21,8 +19,6 @@ describe('Item', function () {
     seller = createSeller(Seller)
     buyer = createBuyer(Buyer)
     soldItem1 = createSoldItemNet(Item)
-    soldItem1ZeroNetPrice = createSoldItemNetZero(Item)
-    soldItem1ZeroGrossPrice = createSoldItemGrossZero(Item)
     soldItem2 = createSoldItemGross(Item)
     invoice = createInvoice(Invoice, seller, buyer, [ soldItem1, soldItem2 ])
   })
@@ -66,10 +62,114 @@ describe('Item', function () {
       done()
     })
 
-    it('should set netUnitPrice or grossUnitPrice to 0', function (done) {
-      expect(soldItem1ZeroNetPrice._options).to.have.property('netUnitPrice').that.is.a('number').to.equal(0)
-      expect(soldItem1ZeroGrossPrice._options).to.have.property('grossUnitPrice').that.is.a('number').to.equal(0)
-      done()
+    it ('should support 0 net unit price', function (done) {
+      const item = new Item({
+        label: 'First item',
+        quantity: 2,
+        unit: 'qt',
+        vat: 27, // can be a number
+        netUnitPrice: 0, // calculates net values from per item net
+        comment: 'An item'
+      })
+    
+      const xml = item._generateXML(null, invoice._options.currency)
+      parser.parseString('<wrapper>' + xml + '</wrapper>', function (err, result) {
+        if (err) {
+          return done(err)
+        }
+    
+        const tetel = result.wrapper.tetel[0]
+        // use '0' string comparison because the xml parses elements as string
+        expect(tetel.nettoEgysegar).to.deep.equal(['0'])
+        expect(tetel.nettoErtek).to.deep.equal(['0'])
+        expect(tetel.bruttoErtek).to.deep.equal(['0'])
+        expect(tetel.afaErtek).to.deep.equal(['0'])
+    
+        done()
+      })
+    })
+
+    it ('should support 0 gross unit price', function (done) {
+      const item = new Item({
+        label: 'First item',
+        quantity: 2,
+        unit: 'qt',
+        vat: 27, // can be a number
+        grossUnitPrice: 0, // calculates gross values from per item net
+        comment: 'An item'
+      })
+    
+      const xml = item._generateXML(null, invoice._options.currency)
+      parser.parseString('<wrapper>' + xml + '</wrapper>', function (err, result) {
+        if (err) {
+          return done(err)
+        }
+    
+        const tetel = result.wrapper.tetel[0]
+        // use '0' string comparison because the xml parses elements as string
+        expect(tetel.nettoEgysegar).to.deep.equal(['0'])
+        expect(tetel.nettoErtek).to.deep.equal(['0'])
+        expect(tetel.bruttoErtek).to.deep.equal(['0'])
+        expect(tetel.afaErtek).to.deep.equal(['0'])
+    
+        done()
+      })
+    })
+
+    it ('should support 0 net unit price in case of special vat', function (done) {
+      ['TAM', 'AAM', 'EU', 'EUK', 'MAA', 'ÁKK', 'TEHK', 'HO', 'KBAET'].forEach(function (specialVat) {
+        const item = new Item({
+          label: 'First item',
+          quantity: 2,
+          unit: 'qt',
+          vat: specialVat, // a special string
+          netUnitPrice: 0, // calculates net values from per item net
+          comment: 'An item'
+        })
+      
+        const xml = item._generateXML(null, invoice._options.currency)
+        parser.parseString('<wrapper>' + xml + '</wrapper>', function (err, result) {
+          if (err) {
+            return done(err)
+          }
+      
+          const tetel = result.wrapper.tetel[0]
+          // use '0' string comparison because the xml parses elements as string
+          expect(tetel.nettoEgysegar).to.deep.equal(['0'])
+          expect(tetel.nettoErtek).to.deep.equal(['0'])
+          expect(tetel.bruttoErtek).to.deep.equal(['0'])
+          expect(tetel.afaErtek).to.deep.equal(['0'])
+      })
+    })
+    done()
+    })
+
+    it ('should support 0 gross unit price in case of special vat', function (done) {
+      ['TAM', 'AAM', 'EU', 'EUK', 'MAA', 'ÁKK', 'TEHK', 'HO', 'KBAET'].forEach(function (specialVat) {
+        const item = new Item({
+          label: 'First item',
+          quantity: 2,
+          unit: 'qt',
+          vat: specialVat, // a special string
+          grossUnitPrice: 0, // calculates gross values from per item net
+          comment: 'An item'
+        })
+      
+        const xml = item._generateXML(null, invoice._options.currency)
+        parser.parseString('<wrapper>' + xml + '</wrapper>', function (err, result) {
+          if (err) {
+            return done(err)
+          }
+      
+          const tetel = result.wrapper.tetel[0]
+          // use '0' string comparison because the xml parses elements as string
+          expect(tetel.nettoEgysegar).to.deep.equal(['0'])
+          expect(tetel.nettoErtek).to.deep.equal(['0'])
+          expect(tetel.bruttoErtek).to.deep.equal(['0'])
+          expect(tetel.afaErtek).to.deep.equal(['0'])
+      })
+    })
+    done()
     })
     
     it('should calculate vatValue', function (done) {

--- a/tests/item.spec.js
+++ b/tests/item.spec.js
@@ -5,13 +5,15 @@ const parser = new xml2js.Parser()
 import {expect} from 'chai'
 
 import {Buyer, Invoice, Item, Seller} from '../index.js'
-import {createSeller, createBuyer, createSoldItemNet, createSoldItemGross, createInvoice} from './resources/setup.js'
+import {createSeller, createBuyer, createSoldItemNet, createSoldItemGross, createInvoice, createSoldItemNetZero, createSoldItemGrossZero} from './resources/setup.js'
 
 describe('Item', function () {
 
   let seller
   let buyer
   let soldItem1
+  let soldItem1ZeroNetPrice
+  let soldItem1ZeroGrossPrice
   let soldItem2
   let invoice
 
@@ -19,6 +21,8 @@ describe('Item', function () {
     seller = createSeller(Seller)
     buyer = createBuyer(Buyer)
     soldItem1 = createSoldItemNet(Item)
+    soldItem1ZeroNetPrice = createSoldItemNetZero(Item)
+    soldItem1ZeroGrossPrice = createSoldItemGrossZero(Item)
     soldItem2 = createSoldItemGross(Item)
     invoice = createInvoice(Invoice, seller, buyer, [ soldItem1, soldItem2 ])
   })
@@ -52,6 +56,14 @@ describe('Item', function () {
     it('should set netUnitPrice or grossUnitPrice', function (done) {
       let price = soldItem1._options.netUnitPrice || soldItem1._options.grossUnitPrice
       expect(price).is.a('number')
+      done()
+    })
+
+    it('should set netUnitPrice or grossUnitPrice to 0', function (done) {
+      let netUnitPriceZero = soldItem1ZeroNetPrice._options.netUnitPrice;
+      let grossUnitPriceZero = soldItem1ZeroGrossPrice._options.grossUnitPrice;
+      expect(netUnitPriceZero).is.a('number').to.equal(0)
+      expect(grossUnitPriceZero).is.a('number').to.equal(0)
       done()
     })
   })

--- a/tests/resources/setup.js
+++ b/tests/resources/setup.js
@@ -96,6 +96,21 @@ export function createSoldItemNet(Item) {
 }
 
 /**
+ * Create sold item with net price 0
+ * @return {Item}
+ */
+export function createSoldItemNetZero(Item) {
+  return new Item({
+    label: 'First item',
+    quantity: 2,
+    unit: 'qt',
+    vat: 27, // can be a number or a special string
+    netUnitPrice: 0, // calculates gross and net values from per item net
+    comment: 'An item'
+  })
+}
+
+/**
  * Create sold item with gross price
  * @return {Item}
  */
@@ -106,6 +121,20 @@ export function createSoldItemGross(Item) {
     unit: 'qt',
     vat: 27,
     grossUnitPrice: 1270 // calculates net and total values from per item gross
+  })
+}
+
+/**
+ * Create sold item with gross price 0
+ * @return {Item}
+ */
+export function createSoldItemGrossZero(Item) {
+  return new Item({
+    label: 'Second item',
+    quantity: 5,
+    unit: 'qt',
+    vat: 27,
+    grossUnitPrice: 0 // calculates net and total values from per item gross
   })
 }
 

--- a/tests/resources/setup.js
+++ b/tests/resources/setup.js
@@ -96,21 +96,6 @@ export function createSoldItemNet(Item) {
 }
 
 /**
- * Create sold item with net price 0
- * @return {Item}
- */
-export function createSoldItemNetZero(Item) {
-  return new Item({
-    label: 'First item',
-    quantity: 2,
-    unit: 'qt',
-    vat: 27, // can be a number or a special string
-    netUnitPrice: 0, // calculates gross and net values from per item net
-    comment: 'An item'
-  })
-}
-
-/**
  * Create sold item with gross price
  * @return {Item}
  */
@@ -121,20 +106,6 @@ export function createSoldItemGross(Item) {
     unit: 'qt',
     vat: 27,
     grossUnitPrice: 1270 // calculates net and total values from per item gross
-  })
-}
-
-/**
- * Create sold item with gross price 0
- * @return {Item}
- */
-export function createSoldItemGrossZero(Item) {
-  return new Item({
-    label: 'Second item',
-    quantity: 5,
-    unit: 'qt',
-    vat: 27,
-    grossUnitPrice: 0 // calculates net and total values from per item gross
   })
 }
 


### PR DESCRIPTION
Added support for `0` unit price for `netUnitPrice` & `grossUnitPrice`.