### PR TITLE
feat: finalInvoice

### DIFF
--- a/lib/Invoice.js
+++ b/lib/Invoice.js
@@ -36,6 +36,8 @@ export class Invoice {
     this._options.logoImage = options.logoImage
     this._options.adjustmentInvoiceNumber = options.adjustmentInvoiceNumber
     this._options.prepaymentInvoice = options.prepaymentInvoice || false
+    this._options.finalInvoice = options.finalInvoice || false
+    this._options.prepaymentInvoiceNumber = options.prepaymentInvoiceNumber
   }
 
   _generateXML (indentLevel) {
@@ -75,6 +77,12 @@ export class Invoice {
     this._options.adjustmentInvoice = true
   }
 
+  if (this._options.prepaymentInvoiceNumber !== null && this._options.prepaymentInvoiceNumber !== undefined) {
+    assert(typeof this._options.prepaymentInvoiceNumber === 'string', '"prepaymentInvoiceNumber" should be a string')
+    assert(this._options.prepaymentInvoiceNumber.length > 0, '"prepaymentInvoiceNumber" should be minimum 1 character')
+    assert(this._options.finalInvoice === true, '"prepaymentInvoiceNumber" should only be set if "finalInvoice" is true')
+  }
+
     let o = wrapWithElement('fejlec', [
       [ 'keltDatum', this._options.issueDate ],
       [ 'teljesitesDatum', this._options.fulfillmentDate ],
@@ -89,6 +97,8 @@ export class Invoice {
       [ 'elolegszamla', this._options.prepaymentInvoice ],
       [ 'helyesbitoszamla', this._options.adjustmentInvoice ],
       [ 'helyesbitettSzamlaszam', this._options.adjustmentInvoiceNumber ],
+      [ 'vegszamla', this._options.finalInvoice ],
+      [ 'elolegSzamlaszam', this._options.prepaymentInvoiceNumber ],
       [ 'dijbekero', this._options.proforma ],
       [ 'logoExtra', this._options.logoImage ],
       [ 'szamlaszamElotag', this._options.invoiceIdPrefix ],

--- a/tests/invoice.spec.js
+++ b/tests/invoice.spec.js
@@ -207,6 +207,132 @@ describe('Invoice', function () {
       });
       // END - New test suite for adjustmentInvoiceNumber property
 
+      describe('prepaymentInvoiceNumber validation', function () {
+        it('should throw an error when finalInvoice is not set', function () {
+          expect(() => {
+            invoice = new Invoice({
+              prepaymentInvoiceNumber: '1234',
+              paymentMethod: PaymentMethod.BankTransfer,
+              currency: Currency.Ft,
+              language: Language.Hungarian,
+              seller: seller,
+              buyer: buyer,
+              items: [soldItem1, soldItem2],
+            });
+            invoice._generateXML();
+          }).to.throw(/"prepaymentInvoiceNumber" should only be set if "finalInvoice" is true/);
+        });
+
+        it('should throw an error when finalInvoice is false', function () {
+          expect(() => {
+            invoice = new Invoice({
+              finalInvoice: false,
+              prepaymentInvoiceNumber: '1234',
+              paymentMethod: PaymentMethod.BankTransfer,
+              currency: Currency.Ft,
+              language: Language.Hungarian,
+              seller: seller,
+              buyer: buyer,
+              items: [soldItem1, soldItem2],
+            });
+            invoice._generateXML();
+          }).to.throw(/"prepaymentInvoiceNumber" should only be set if "finalInvoice" is true/);
+        });
+
+        it('should throw an error when prepaymentInvoiceNumber is an empty string', function () {
+          expect(() => {
+            invoice = new Invoice({
+              prepaymentInvoiceNumber: '',
+              paymentMethod: PaymentMethod.BankTransfer,
+              currency: Currency.Ft,
+              language: Language.Hungarian,
+              seller: seller,
+              buyer: buyer,
+              items: [soldItem1, soldItem2],
+            });
+            invoice._generateXML();
+          }).to.throw(/"prepaymentInvoiceNumber" should be minimum 1 character/);
+        });
+
+        it('should throw an error when prepaymentInvoiceNumber is a Date object', function () {
+          expect(() => {
+            invoice = new Invoice({
+              paymentMethod: PaymentMethod.BankTransfer,
+              currency: Currency.Ft,
+              language: Language.Hungarian,
+              seller: seller,
+              buyer: buyer,
+              items: [soldItem1, soldItem2],
+              prepaymentInvoiceNumber: new Date()
+            });
+            invoice._generateXML();
+          }).to.throw(/"prepaymentInvoiceNumber" should be a string/);
+        });
+
+        it('should throw an error when prepaymentInvoiceNumber is a number', function () {
+          invoice = new Invoice({
+            paymentMethod: PaymentMethod.BankTransfer,
+            currency: Currency.Ft,
+            language: Language.Hungarian,
+            seller: seller,
+            buyer: buyer,
+            items: [soldItem1, soldItem2],
+            prepaymentInvoiceNumber: 123
+          });
+          expect(() => {
+            invoice._generateXML();
+          }).to.throw(/"prepaymentInvoiceNumber" should be a string/);
+        });
+
+        it('should throw an error when prepaymentInvoiceNumber is a boolean', function () {
+          const invoice = new Invoice({
+            paymentMethod: PaymentMethod.BankTransfer,
+            currency: Currency.Ft,
+            language: Language.Hungarian,
+            seller: seller,
+            buyer: buyer,
+            items: [soldItem1, soldItem2],
+            prepaymentInvoiceNumber: true
+          });
+          expect(() => {
+            invoice._generateXML();
+          }).to.throw(/"prepaymentInvoiceNumber" should be a string/);
+        });
+
+        it('should not throw an error when prepaymentInvoiceNumber is a non-empty string and finalInvoice is true', function () {
+          expect(() => {
+            const invoice = new Invoice({
+              paymentMethod: PaymentMethod.BankTransfer,
+              currency: Currency.Ft,
+              language: Language.Hungarian,
+              seller: seller,
+              buyer: buyer,
+              items: [soldItem1, soldItem2],
+              finalInvoice: true,
+              prepaymentInvoiceNumber: '12345'
+            });
+            invoice._generateXML();
+          }).to.not.throw();
+        });
+
+        it('should include prepaymentInvoiceNumber when it is a non-empty string and finalInvoice is true', function (done) {
+          const invoice = new Invoice({
+            paymentMethod: PaymentMethod.BankTransfer,
+            currency: Currency.Ft,
+            language: Language.Hungarian,
+            seller: seller,
+            buyer: buyer,
+            items: [soldItem1, soldItem2],
+            finalInvoice: true,
+            prepaymentInvoiceNumber: '12345'
+          });
+          parser.parseString('<wrapper>' + invoice._generateXML() + '</wrapper>', function (err, result) {
+            expect(result.wrapper.fejlec[0].elolegSzamlaszam[0]).to.equal('12345');
+            done(err);
+          });
+        });
+      });
+
       describe('NAV reporting', function () {
         it('should not include noNavReport when it is null.', function (done) {
           const invoice = new Invoice({


### PR DESCRIPTION
This PR adds support for creating final invoices.
It introduces two new fields to the Invoice class:
- `finalInvoice`: bool - it indicates whether the invoice is a final invoice
- `prepaymentInvoiceNumber`: string - not always needed, but contains the `invoiceId` of the prepayment invoice to which this final invoice belongs

Since `prepaymentInvoiceNumber` is not required for creating a final invoice (at least according to the documentation), I did not used the same pattern as what the `adjustmentInvoiceNumber` field is doing (hiding the `adjustmentInvoice` field behind it).