### PR TITLE
Implement queryTaxPayer & registerCreditEntry function

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,38 @@ Response
 }
 ```
 
+### Query tax payer
+
+Through this interface, it is possible to query the correctness of a given tax number and the taxpayer's details. The response always matches the QueryTaxPayerResponse type of Online Invoice Platform of NAV, the Hungarian National Tax and Customs Administration.
+
+```javascript
+const szamlazzClient = new Client({
+  authToken: 'SZAMLAAGENTKEY',
+})
+
+const taxPayer = await szamlazzClient.queryTaxPayer(12345678) //8 digit taxpayerId
+```
+
+Response
+```javascript
+{
+  taxpayerValidity: true,
+  taxpayerId: '12345678',
+  vatCode: '2',
+  countyCode: '41',
+  taxpayerName: 'taxpayerName KERESKEDELMI ÉS SZOLGÁLTATÓ KORLÁTOLT FELELŐSSÉGŰ TÁRSASÁG',
+  taxpayerShortName: 'taxpayerName KFT.',
+  address: {
+    countryCode: 'HU',
+    postalCode: '1000',
+    city: 'BUDAPEST',
+    streetName: 'TESZT',
+    publicPlaceCategory: 'UTCA',
+    number: '1.'
+  }
+}
+```
+
 ## Constants
 
 ### PaymentMethod

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ import {
   PaymentMethod,
   PaymentMethods,
   TaxSubject,
-  TaxSubjects} from 'szamlazz.js'
+  TaxSubjects,
+  CreditEntry} from 'szamlazz.js'
 ```
 
 ### Create a client
@@ -120,6 +121,18 @@ let soldItem2 = new Item({
   unit: 'qt',
   vat: 27,
   grossUnitPrice: 1270 // calculates net and total values from per item gross
+})
+```
+
+### Create a credit entry
+
+With net unit price:
+```javascript
+let creditEntry = new CreditEntry({
+  amount: 1000,
+  paymentMethod: PaymentMethods.BankTransfer,
+  description: '', // Default is mempty
+  date: new Date() // Default is current date
 })
 ```
 
@@ -240,6 +253,35 @@ Response
     publicPlaceCategory: 'UTCA',
     number: '1.'
   }
+}
+```
+
+### Registering credit entry
+
+You can use this interface to record a credit (deposit) to an invoice you have previously created. Basically you can use this to mark an invoice as paid.
+
+```javascript
+const szamlazzClient = new Client({
+  authToken: 'SZAMLAAGENTKEY',
+})
+
+const creditEntry = new CreditEntry({
+  amount: 1000
+});
+
+const creditEntryResponse = await szamlazzClient.registerCreditEntry({
+  invoiceId: 'WXSKA-2020-00',
+  additive: true, // Default is true
+  taxNumber: '' // Default is empty
+}, [creditEntry])
+```
+
+Response
+```javascript
+{
+  invoiceId: 'WXSKA-2020-00', // The id of the created  invoice
+  netTotal: '1000',           // Total value of the  invoice excl. VAT
+  grossTotal: '1270',         // Total value of the  invoice incl. VAT
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ const szamlazzClient = new Client({
   authToken: 'SZAMLAAGENTKEY',
 })
 
-const taxPayer = await szamlazzClient.queryTaxPayer(12345678) //8 digit taxpayerId
+const taxPayer = await szamlazzClient.queryTaxPayer('12345678') //8 digit taxpayerId(as string)
 ```
 
 Response

--- a/index.js
+++ b/index.js
@@ -4,5 +4,6 @@ import {Currencies, Currency, Language, Languages, PaymentMethod, PaymentMethods
 import {Invoice} from './lib/Invoice.js'
 import {Item} from './lib/Item.js'
 import {Seller} from './lib/Seller.js'
+import {CreditEntry} from './lib/CreditEntry.js'
 
-export {Buyer, Client, Invoice, Item, Seller, Currencies, Currency, Language, Languages, PaymentMethod, PaymentMethods, TaxSubject, TaxSubjects}
+export {Buyer, Client, Invoice, Item, Seller, Currencies, Currency, Language, Languages, PaymentMethod, PaymentMethods, TaxSubject, TaxSubjects, CreditEntry}

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2,7 +2,7 @@ import assert from 'assert'
 import merge from 'merge'
 import axios from 'axios'
 import FormData from 'form-data'
-import { parseString, wrapWithElement, xml2obj } from './XMLUtils.js'
+import { parseString, wrapWithElement, xml2obj, removeNamespaces } from './XMLUtils.js'
 import { HttpsCookieAgent } from 'http-cookie-agent/http'
 import tough from 'tough-cookie'
 
@@ -124,6 +124,57 @@ export class Client {
       }
     }
     return data
+  }
+
+  async queryTaxPayer (taxPayerId) {
+    assert(typeof taxPayerId === 'string' && /^[0-9]{8}$/.test(taxPayerId), 'taxPayerId must be an 8-digit number');
+
+    const xml = this._getXmlHeader('xmltaxpayer', 'agent') +
+      wrapWithElement(
+        'beallitasok', [
+          ...this._getAuthFields(),
+        ], 1) +
+        wrapWithElement('torzsszam', taxPayerId, 1) +
+      '</xmltaxpayer>'
+
+    const response = await this._sendRequest('action-szamla_agent_taxpayer', xml)
+    const parsedBody = await parseString(response.data)
+    const cleanParsedBody = removeNamespaces(parsedBody);
+    const cleanParsedBodyData = cleanParsedBody.QueryTaxpayerResponse;
+    const taxpayerValidity = cleanParsedBodyData.taxpayerValidity?.[0] === 'true';
+
+    if (!taxpayerValidity) {
+      return {
+        taxpayerValidity: false,
+      };
+    }
+
+    const taxpayerData = cleanParsedBodyData.taxpayerData?.[0] || {};
+    const taxNumberDetail = taxpayerData.taxNumberDetail?.[0] || {};
+  
+    return {
+      taxpayerValidity,
+      taxpayerId: taxNumberDetail.taxpayerId?.[0] || null,
+      vatCode: taxNumberDetail.vatCode?.[0] || null,
+      countyCode: taxNumberDetail.countyCode?.[0] || null,
+      taxpayerName: taxpayerData.taxpayerName?.[0] || null,
+      taxpayerShortName: taxpayerData.taxpayerShortName?.[0] || null,
+      address: this._extractAddress(taxpayerData.taxpayerAddressList?.[0]),
+    };
+  }
+
+  _extractAddress (addressList) {
+    if (!addressList || !addressList.taxpayerAddressItem) return null;
+
+    const addressItem = addressList.taxpayerAddressItem[0].taxpayerAddress?.[0] || {};
+    return {
+      countryCode: addressItem.countryCode?.[0] || null,
+      postalCode: addressItem.postalCode?.[0] || null,
+      city: addressItem.city?.[0] || null,
+      streetName: addressItem.streetName?.[0] || null,
+      publicPlaceCategory: addressItem.publicPlaceCategory?.[0] || null,
+      number: addressItem.number?.[0] || null,
+    };
   }
 
   _getXmlHeader (tag, dir) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -128,7 +128,7 @@ export class Client {
   }
 
   async queryTaxPayer (taxPayerId) {
-    assert(typeof taxPayerId === 'number' && /^[0-9]{8}$/.test(taxPayerId.toString()), 'taxPayerId must be an 8-digit number');
+    assert(typeof taxPayerId === 'string' && /^[0-9]{8}$/.test(taxPayerId.toString()), 'taxPayerId must be an 8-digit number');
 
     const xml = this._getXmlHeader('xmltaxpayer', 'agent') +
       wrapWithElement(
@@ -201,6 +201,9 @@ export class Client {
       streetName: addressItem.streetName?.[0] || null,
       publicPlaceCategory: addressItem.publicPlaceCategory?.[0] || null,
       number: addressItem.number?.[0] || null,
+      staircase: addressItem.staircase?.[0] || null,
+      door: addressItem.door?.[0] || null,
+      floor: addressItem.floor?.[0] || null
     };
   }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -127,7 +127,7 @@ export class Client {
   }
 
   async queryTaxPayer (taxPayerId) {
-    assert(typeof taxPayerId === 'string' && /^[0-9]{8}$/.test(taxPayerId), 'taxPayerId must be an 8-digit number');
+    assert(typeof taxPayerId === 'number' && /^[0-9]{8}$/.test(taxPayerId.toString()), 'taxPayerId must be an 8-digit number');
 
     const xml = this._getXmlHeader('xmltaxpayer', 'agent') +
       wrapWithElement(

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -5,6 +5,7 @@ import FormData from 'form-data'
 import { parseString, wrapWithElement, xml2obj, removeNamespaces } from './XMLUtils.js'
 import { HttpsCookieAgent } from 'http-cookie-agent/http'
 import tough from 'tough-cookie'
+import { CreditEntry } from './CreditEntry.js';
 
 const defaultOptions = {
   eInvoice: false,
@@ -163,6 +164,32 @@ export class Client {
     };
   }
 
+  async registerCreditEntry (options, creditEntries) {
+    assert(typeof options.invoiceId === 'string' && options.invoiceId.trim().length > 1, 'invoiceId must be specified')
+    assert(Array.isArray(creditEntries) && creditEntries.length > 0, 'creditEntries must be specified and must be an array')
+    assert(creditEntries.every(entry => entry instanceof CreditEntry), 'All entries must be instances of CreditEntry')
+
+    const xml = this._getXmlHeader('xmlszamlakifiz', 'agentkifiz') +
+      wrapWithElement(
+        'beallitasok', [
+          ...this._getAuthFields(),
+          ['szamlaszam', options.invoiceId],
+          ['adoszam', options.taxNumber || ''],
+          ['additiv', String(options.additive || true)],
+        ], 1) +
+        creditEntries.map(creditEntry => creditEntry._generateXML()).join('') +
+      '</xmlszamlakifiz>'
+
+    const httpResponse = await this._sendRequest('action-szamla_agent_kifiz', xml)
+    const data = {
+      invoiceId: httpResponse.headers.szlahu_szamlaszam,
+      netTotal: httpResponse.headers.szlahu_nettovegosszeg,
+      grossTotal: httpResponse.headers.szlahu_bruttovegosszeg,
+    }
+    
+    return data
+  }
+
   _extractAddress (addressList) {
     if (!addressList || !addressList.taxpayerAddressItem) return null;
 
@@ -224,7 +251,7 @@ export class Client {
       throw err
     }
 
-    if (isBinaryDownload) {
+    if (isBinaryDownload || fileFieldName === 'action-szamla_agent_kifiz') { // credit entry response is just a string, not XML
       return httpResponse
     }
 

--- a/lib/CreditEntry.js
+++ b/lib/CreditEntry.js
@@ -1,0 +1,45 @@
+import assert from 'assert'
+import merge from 'merge'
+import {wrapWithElement} from './XMLUtils.js'
+import {PaymentMethod, PaymentMethods} from  './Constants.js'
+
+const defaultOptions = {
+  date: new Date(),
+  paymentMethod: PaymentMethods.BankTransfer,
+  amount: 0,
+  description: '',
+}
+
+export class CreditEntry {
+  constructor (options) {
+    this._options = {};
+    this._options.date = options.date || new Date()
+    this._options.paymentMethod = options.paymentMethod || defaultOptions.paymentMethod
+    this._options.amount = options.amount || defaultOptions.amount
+    this._options.description = options.description || ''
+
+    assert(this._options.paymentMethod instanceof PaymentMethod,
+      'Valid PaymentMethod field missing from credit entry options')
+
+    assert(this._options.date instanceof Date,
+      'Valid Date field missing from credit entry options')
+
+    assert(typeof this._options.amount === 'number' && this._options.amount !== 0,
+      'Valid Amount value missing from credit entry options')
+
+    assert(typeof this._options.description === 'string' || this._options.description === '',
+      'Valid Description value missing from credit entry options')
+
+  }
+
+  _generateXML (indentLevel) {
+    indentLevel = indentLevel || 0
+
+    return wrapWithElement('kifizetes', [
+      [ 'datum', this._options.date ],
+      [ 'jogcim', this._options.paymentMethod.value ],
+      [ 'osszeg', this._options.amount ],
+      [ 'leiras', this._options.description ],
+    ], indentLevel)
+  }
+}

--- a/lib/CreditEntry.js
+++ b/lib/CreditEntry.js
@@ -1,21 +1,13 @@
 import assert from 'assert'
-import merge from 'merge'
 import {wrapWithElement} from './XMLUtils.js'
 import {PaymentMethod, PaymentMethods} from  './Constants.js'
-
-const defaultOptions = {
-  date: new Date(),
-  paymentMethod: PaymentMethods.BankTransfer,
-  amount: 0,
-  description: '',
-}
 
 export class CreditEntry {
   constructor (options) {
     this._options = {};
     this._options.date = options.date || new Date()
-    this._options.paymentMethod = options.paymentMethod || defaultOptions.paymentMethod
-    this._options.amount = options.amount || defaultOptions.amount
+    this._options.paymentMethod = options.paymentMethod || PaymentMethods.BankTransfer
+    this._options.amount = options.amount || 0
     this._options.description = options.description || ''
 
     assert(this._options.paymentMethod instanceof PaymentMethod,

--- a/lib/Item.js
+++ b/lib/Item.js
@@ -46,7 +46,7 @@ export class Item {
         throw new Error('Net or Gross Value is required for Item price calculation')
       }
     } else if (typeof this._options.vat === 'string') {
-      if (['TAM', 'AAM', 'EU', 'EUK', 'MAA', 'ÁKK', 'TEHK', 'HO', 'KBAET', 'K.AFA].includes(this._options.vat)) {
+      if (['TAM', 'AAM', 'EU', 'EUK', 'MAA', 'ÁKK', 'TEHK', 'HO', 'KBAET', 'K.AFA'].includes(this._options.vat)) {
         if (typeof this._options.netUnitPrice === 'number') {
           this._options.netValue = round(this._options.netUnitPrice * this._options.quantity, currency.roundPriceExp)
           this._options.vatValue = 0

--- a/lib/Item.js
+++ b/lib/Item.js
@@ -68,6 +68,7 @@ export class Item {
 
     return wrapWithElement('tetel', [
       [ 'megnevezes', this._options.label ],
+      [ 'azonosito', this._options.id ],
       [ 'mennyiseg', this._options.quantity ],
       [ 'mennyisegiEgyseg', this._options.unit ],
       [ 'nettoEgysegar', this._options.netUnitPrice ],

--- a/lib/Item.js
+++ b/lib/Item.js
@@ -46,7 +46,7 @@ export class Item {
         throw new Error('Net or Gross Value is required for Item price calculation')
       }
     } else if (typeof this._options.vat === 'string') {
-      if (['TAM', 'AAM', 'EU', 'EUK', 'MAA', 'ÁKK', 'TEHK', 'HO', 'KBAET'].includes(this._options.vat)) {
+      if (['TAM', 'AAM', 'EU', 'EUK', 'MAA', 'ÁKK', 'TEHK', 'HO', 'KBAET', 'K.AFA].includes(this._options.vat)) {
         if (typeof this._options.netUnitPrice === 'number') {
           this._options.netValue = round(this._options.netUnitPrice * this._options.quantity, currency.roundPriceExp)
           this._options.vatValue = 0

--- a/lib/XMLUtils.js
+++ b/lib/XMLUtils.js
@@ -95,3 +95,17 @@ export async function xml2obj(xml, objList) {
 
   return hash
 }
+
+export function removeNamespaces(obj) {
+  if (Array.isArray(obj)) {
+    return obj.map(removeNamespaces);
+  } else if (typeof obj === 'object' && obj !== null) {
+    return Object.fromEntries(
+      Object.entries(obj).map(([key, value]) => [
+        key.replace(/^.*:/, ''), // Remove the namespace prefix
+        removeNamespaces(value)
+      ])
+    );
+  }
+  return obj;
+}

--- a/tests/client.spec.js
+++ b/tests/client.spec.js
@@ -261,7 +261,6 @@ describe('Client', () => {
 
   })
 
-
   describe('getInvoiceData', () => {
     describe('unsuccessful invoice generation', () => {
       beforeEach(() => {
@@ -278,6 +277,54 @@ describe('Client', () => {
         })).rejectedWith('Hiányzó adat: számla agent xml lekérés hiba (ismeretlen számlaszám).')
       })
     })
+  })
+
+  describe('queryTaxPayer', () => {
+    describe('when the taxpayer ID is invalid', () => {
+      beforeEach(() => {
+        nock('https://www.szamlazz.hu')
+          .post('/szamla/')
+          .replyWithFile(200, RESPONSE_FILE_PATHS.INVALID_TAXPAYER);
+      });
+  
+      it('should return taxpayerValidity as false', async () => {
+        const result = await client.queryTaxPayer(12345678);
+        
+        expect(result).to.deep.equal({
+          taxpayerValidity: false,
+        });
+      });
+    });
+
+    describe('when the taxpayer ID is valid', () => {
+      beforeEach(() => {
+        nock('https://www.szamlazz.hu')
+          .post('/szamla/')
+          .replyWithFile(200, RESPONSE_FILE_PATHS.VALID_TAXPAYER);
+      });
+  
+      it('should return correct taxpayer details', async () => {
+        const result = await client.queryTaxPayer(12345678);
+  
+        expect(result).to.deep.equal({
+          taxpayerValidity: true,
+          taxpayerId: '12345678',
+          vatCode: '2',
+          countyCode: '41',
+          taxpayerName: 'taxpayerName',
+          taxpayerShortName: 'taxpayerShortName',
+          address: {
+            countryCode: 'HU',
+            postalCode: '1000',
+            city: 'BUDAPEST',
+            streetName: 'TESZT',
+            publicPlaceCategory: 'UTCA',
+            number: '1.'
+          },
+        });
+      });
+    });
+  
   })
 })
 

--- a/tests/client.spec.js
+++ b/tests/client.spec.js
@@ -355,9 +355,7 @@ describe('Client', () => {
           .replyWithFile(200, RESPONSE_FILE_PATHS.SUCCESS_WITHOUT_PDF, {
             szlahu_bruttovegosszeg: '6605',
             szlahu_nettovegosszeg: '5201',
-            szlahu_szamlaszam: '2016-139',
-            szlahu_vevoifiokurl: 'https://www.szamlazz.hu/szamla/fiok/gd82embu556d2qjagzj3s2ijqeqzds4ckhuf',
-
+            szlahu_szamlaszam: '2016-139'
           })
       })
 

--- a/tests/creditentry.spec.js
+++ b/tests/creditentry.spec.js
@@ -1,0 +1,62 @@
+/* eslint-env mocha */
+
+import xml2js from 'xml2js'
+const parser = new xml2js.Parser()
+import { expect } from 'chai'
+
+import {CreditEntry} from '../index.js'
+import {createCreditEntry} from './resources/setup.js'
+
+describe('CreditEntry', function () {
+  let creditEntry
+
+  beforeEach(function () {
+    creditEntry = createCreditEntry(CreditEntry)
+  })
+
+  describe('constructor', function () {
+    it('should set _options property', function () {
+      expect(creditEntry).to.have.property('_options').that.is.an('object')
+    })
+  })
+
+  describe('_generateXML', function () {
+    it('should return valid XML', function (done) {
+      parser.parseString(creditEntry._generateXML(), function (err, result) {
+        if (!err) {
+          expect(result).to.have.property('kifizetes').that.is.an('object')
+          done()
+        }
+      })
+    })
+
+    describe('generated XML', function () {
+      let obj
+
+      beforeEach(function (done) {
+        parser.parseString(creditEntry._generateXML(), function (err, result) {
+          if (!err) obj = result.kifizetes
+
+          done()
+        })
+
+      })
+
+      it('should have `datum` property', function () {
+        expect(obj).to.have.property('datum')
+      })
+
+      it('should have `jogcim` property', function () {
+        expect(obj).to.have.property('jogcim')
+      })
+
+      it('should have `osszeg` property', function () {
+        expect(obj).to.have.property('osszeg')
+      })
+
+      it('should have `leiras` property', function () {
+        expect(obj).to.have.property('leiras')
+      })
+    })
+  })
+})

--- a/tests/resources/invalid_taxpayer.xml
+++ b/tests/resources/invalid_taxpayer.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<QueryTaxpayerResponse >
+	<taxpayerValidity>false</taxpayerValidity>
+</QueryTaxpayerResponse>

--- a/tests/resources/setup.js
+++ b/tests/resources/setup.js
@@ -5,7 +5,9 @@ import {Currency, Language, PaymentMethod, TaxSubjects} from "../../lib/Constant
 export const RESPONSE_FILE_PATHS = Object.freeze({
   SUCCESS_WITH_PDF: join(import.meta.url, 'success_with_pdf.xml'),
   SUCCESS_WITHOUT_PDF: join(import.meta.url, 'success_without_pdf.xml'),
-  UNKNOWN_INVOICE_NUMBER: join(import.meta.url, 'unknown_invoice_number.xml')
+  UNKNOWN_INVOICE_NUMBER: join(import.meta.url, 'unknown_invoice_number.xml'),
+  INVALID_TAXPAYER: join(import.meta.url, 'invalid_taxpayer.xml'),
+  VALID_TAXPAYER: join(import.meta.url, 'valid_taxpayer.xml')
 })
 
 /**

--- a/tests/resources/setup.js
+++ b/tests/resources/setup.js
@@ -126,3 +126,17 @@ export function createInvoice(Invoice, seller, buyer, items) {
     items
   })
 }
+
+/**
+ * Create credit entry
+ * Optional and can be used to override the default data.
+ * @return {CreditEntry}
+ */
+export function createCreditEntry(CreditEntry) {
+  return new CreditEntry({
+    paymentMethod: PaymentMethod.BankTransfer,
+    amount: 1000,
+    date: new Date(),
+    description: 'optional description'
+  })
+}

--- a/tests/resources/valid_taxpayer.xml
+++ b/tests/resources/valid_taxpayer.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<QueryTaxpayerResponse >
+	<taxpayerValidity>true</taxpayerValidity>
+	<taxpayerData>
+		<taxpayerName>taxpayerName</taxpayerName>
+		<taxpayerShortName>taxpayerShortName</taxpayerShortName>
+		<taxNumberDetail>
+			<ns2:taxpayerId>12345678</ns2:taxpayerId>
+			<ns2:vatCode>2</ns2:vatCode>
+			<ns2:countyCode>41</ns2:countyCode>
+		</taxNumberDetail>
+		<incorporation>ORGANIZATION</incorporation>
+		<taxpayerAddressList>
+			<taxpayerAddressItem>
+				<taxpayerAddressType>HQ</taxpayerAddressType>
+				<taxpayerAddress>
+					<ns2:countryCode>HU</ns2:countryCode>
+					<ns2:postalCode>1000</ns2:postalCode>
+					<ns2:city>BUDAPEST</ns2:city>
+					<ns2:streetName>TESZT</ns2:streetName>
+					<ns2:publicPlaceCategory>UTCA</ns2:publicPlaceCategory>
+					<ns2:number>1.</ns2:number>
+				</taxpayerAddress>
+			</taxpayerAddressItem>
+		</taxpayerAddressList>
+	</taxpayerData>
+</QueryTaxpayerResponse>


### PR DESCRIPTION
This pull request introduces the queryTaxPayer function, which queries taxpayer details from the Számlázz.hu API(which mirrors the NAV API). The implementation ensures proper XML handling, response parsing. The response contains the validity of the tax payer id and if its valid, it will return the address and name in the following format:

```javascript
{
  taxpayerValidity: true,
  taxpayerId: '12345678',
  vatCode: '2',
  countyCode: '41',
  taxpayerName: 'taxpayerName KERESKEDELMI ÉS SZOLGÁLTATÓ KORLÁTOLT FELELŐSSÉGŰ TÁRSASÁG',
  taxpayerShortName: 'taxpayerName KFT.',
  address: {
    countryCode: 'HU',
    postalCode: '1000',
    city: 'BUDAPEST',
    streetName: 'TESZT',
    publicPlaceCategory: 'UTCA',
    number: '1.'
  }
}
```

Also adds the registerCreditEntry function, which you can use to mark an invoice as paid by registering a credit entry. 