### PR TITLE
feat: drop node 18 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22, 23]
+        node-version: [20, 22, 23]
 
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "exports": "./index.js",
   "engines": {
-    "node": ">=14.13.1 || >=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha 'tests/*.spec.js'",


### PR DESCRIPTION
BREAKING CHANGE: node 20+ required. Node 18 will reach end of life support at the end of 2025 April